### PR TITLE
totalBytesReleaseable should be long

### DIFF
--- a/src/main/java/com/cloudera/support/hbase/ArchiveFileSnapshotReference.java
+++ b/src/main/java/com/cloudera/support/hbase/ArchiveFileSnapshotReference.java
@@ -59,7 +59,7 @@ public class ArchiveFileSnapshotReference {
     references.checkArchiveFolder(new Path(args[0]), filesToCheck);
 
     int countDeletable = 0;
-    int totalBytesReleaseable = 0;
+    long totalBytesReleaseable = 0;
 
     for (FileStatus f : references.fileCleaner.getDeletableFiles(filesToCheck)) {
 


### PR DESCRIPTION
totalBytesReleaseable should be long, instead of int, in case where TiB of data is deletable, otherwise, it's overflowed and report a negative value. We saw that in a case 238844, tool.output.gz.